### PR TITLE
Add margin/indentation feature for a single prompt

### DIFF
--- a/lib/elements/autocomplete.js
+++ b/lib/elements/autocomplete.js
@@ -249,7 +249,7 @@ class AutocompletePrompt extends Prompt {
       }
     }
 
-    this.out.write(erase.line + cursor.to(0) + this.outputText);
+    this.out.write(erase.line + cursor.to(0) + wrap(this.outputText, { margin: this.margin }));
   }
 }
 

--- a/lib/elements/autocompleteMultiselect.js
+++ b/lib/elements/autocompleteMultiselect.js
@@ -3,7 +3,7 @@
 const color = require('kleur');
 const { cursor } = require('sisteransi');
 const MultiselectPrompt = require('./multiselect');
-const { clear, style, figures } = require('../util');
+const { clear, style, figures, wrap } = require('../util');
 /**
  * MultiselectPrompt Base Element
  * @param {Object} opts Options
@@ -186,7 +186,7 @@ Filtered results for: ${this.inputValue ? this.inputValue : color.gray('Enter so
     }
     prompt += this.renderOptions(this.filteredOptions);
 
-    this.out.write(this.clear + prompt);
+    this.out.write(this.clear + wrap(prompt, { margin: this.margin }));
     this.clear = clear(prompt);
   }
 }

--- a/lib/elements/confirm.js
+++ b/lib/elements/confirm.js
@@ -1,6 +1,6 @@
 const color = require('kleur');
 const Prompt = require('./prompt');
-const { style, clear } = require('../util');
+const { style, clear, wrap } = require('../util');
 const { erase, cursor } = require('sisteransi');
 
 /**
@@ -78,7 +78,7 @@ class ConfirmPrompt extends Prompt {
           : color.gray(this.initialValue ? this.yesOption : this.noOption)
     ].join(' ');
 
-    this.out.write(erase.line + cursor.to(0) + this.outputText);
+    this.out.write(erase.line + cursor.to(0) + wrap(this.outputText, { margin: this.margin }));
   }
 }
 

--- a/lib/elements/date.js
+++ b/lib/elements/date.js
@@ -2,7 +2,7 @@
 
 const color = require('kleur');
 const Prompt = require('./prompt');
-const { style, clear, figures } = require('../util');
+const { style, clear, figures, wrap } = require('../util');
 const { erase, cursor } = require('sisteransi');
 const { DatePart, Meridiem, Day, Hours, Milliseconds, Minutes, Month, Seconds, Year } = require('../dateparts');
 
@@ -198,7 +198,7 @@ class DatePrompt extends Prompt {
           (a, l, i) => a + `\n${i ? ` ` : figures.pointerSmall} ${color.red().italic(l)}`, ``);
     }
 
-    this.out.write(erase.line + cursor.to(0) + this.outputText);
+    this.out.write(erase.line + cursor.to(0) + wrap(this.outputText, { margin: this.margin }));
   }
 }
 

--- a/lib/elements/multiselect.js
+++ b/lib/elements/multiselect.js
@@ -260,7 +260,7 @@ class MultiselectPrompt extends Prompt {
     }
     prompt += this.renderOptions(this.value);
 
-    this.out.write(this.clear + prompt);
+    this.out.write(this.clear + wrap(prompt, { margin: this.margin }));
     this.clear = clear(prompt);
   }
 }

--- a/lib/elements/number.js
+++ b/lib/elements/number.js
@@ -1,7 +1,7 @@
 const color = require('kleur');
 const Prompt = require('./prompt');
 const { cursor, erase } = require('sisteransi');
-const { style, figures, clear, lines } = require('../util');
+const { style, figures, clear, lines, wrap } = require('../util');
 
 const isNumber = /[0-9]/;
 const isDef = any => any !== undefined;
@@ -202,7 +202,7 @@ class NumberPrompt extends Prompt {
           .reduce((a, l, i) => a + `\n${i ? ` ` : figures.pointerSmall} ${color.red().italic(l)}`, ``);
     }
 
-    this.out.write(erase.line + cursor.to(0) + this.outputText + cursor.save + this.outputError + cursor.restore);
+    this.out.write(erase.line + cursor.to(0) + wrap(this.outputText + cursor.save + this.outputError + cursor.restore, { margin: this.margin }));
   }
 }
 

--- a/lib/elements/prompt.js
+++ b/lib/elements/prompt.js
@@ -15,6 +15,8 @@ class Prompt extends EventEmitter {
   constructor(opts={}) {
     super();
 
+    this.margin = (opts.margin > 0) ? opts.margin - 1 : 0;
+
     this.firstRender = true;
     this.in = opts.stdin || process.stdin;
     this.out = opts.stdout || process.stdout;

--- a/lib/elements/select.js
+++ b/lib/elements/select.js
@@ -145,7 +145,7 @@ class SelectPrompt extends Prompt {
             .join('\n');
     }
 
-    this.out.write(this.outputText);
+    this.out.write(wrap(this.outputText, { margin: this.margin }));
   }
 }
 

--- a/lib/elements/text.js
+++ b/lib/elements/text.js
@@ -1,7 +1,7 @@
 const color = require('kleur');
 const Prompt = require('./prompt');
 const { erase, cursor } = require('sisteransi');
-const { style, clear, lines, figures } = require('../util');
+const { style, clear, lines, figures, wrap } = require('../util');
 
 /**
  * TextPrompt Base Element
@@ -174,7 +174,7 @@ class TextPrompt extends Prompt {
           .reduce((a, l, i) => a + `\n${i ? ' ' : figures.pointerSmall} ${color.red().italic(l)}`, ``);
     }
 
-    this.out.write(erase.line + cursor.to(0) + this.outputText + cursor.save + this.outputError + cursor.restore);
+    this.out.write(erase.line + cursor.to(0) + wrap(this.outputText + cursor.save + this.outputError + cursor.restore, { margin: this.margin }));
   }
 }
 

--- a/lib/elements/toggle.js
+++ b/lib/elements/toggle.js
@@ -1,6 +1,6 @@
 const color = require('kleur');
 const Prompt = require('./prompt');
-const { style, clear } = require('../util');
+const { style, clear, wrap } = require('../util');
 const { cursor, erase } = require('sisteransi');
 
 /**
@@ -107,7 +107,7 @@ class TogglePrompt extends Prompt {
       this.value ? color.cyan().underline(this.active) : this.active
     ].join(' ');
 
-    this.out.write(erase.line + cursor.to(0) + this.outputText);
+    this.out.write(erase.line + cursor.to(0) + wrap(this.outputText, { margin: this.margin }));
   }
 }
 

--- a/lib/util/wrap.js
+++ b/lib/util/wrap.js
@@ -7,6 +7,8 @@
  * @param {number} [opts.width] Maximum characters per line including the margin
  */
 module.exports = (msg, opts = {}) => {
+  if (parseInt(opts.margin) === 0) return msg || '';
+
   const tab = Number.isSafeInteger(parseInt(opts.margin))
     ? new Array(parseInt(opts.margin)).fill(' ').join('')
     : (opts.margin || '');


### PR DESCRIPTION
This is a kind of workaround solution for supporting to set a margin or an indentation for a single prompt.

It seems to work, but I'm sure there is a better way to implement this feature.

Related to terkelg/prompts#191.